### PR TITLE
Ignore BlockLength rule for specs

### DIFF
--- a/.rubocop.kapost.yml
+++ b/.rubocop.kapost.yml
@@ -17,6 +17,10 @@ AllCops:
     - "spec/fixtures/**/*"
     - "bin/**/*"
     - "script/**/*"
+    
+Metrics/BlockLength:
+  Exclude:
+    - "spec/**/*_spec.rb"
 
 Metrics/LineLength:
   Max: 120


### PR DESCRIPTION
Seems like these are meant to be long